### PR TITLE
standardized file url to suppress warning

### DIFF
--- a/Sources/airdrop/AirDropCLI.swift
+++ b/Sources/airdrop/AirDropCLI.swift
@@ -64,7 +64,7 @@ class AirDropCLI:  NSObject, NSApplicationDelegate, NSSharingServiceDelegate {
 
         for pathToFile in pathsToFiles {
             let fileURL: URL = NSURL.fileURL(withPath: pathToFile, isDirectory: false)
-            filesToShare.append(fileURL)
+            filesToShare.append(fileURL.standardizedFileURL)
         }
 
         if service.canPerform(withItems: filesToShare) {


### PR DESCRIPTION
before standardize if we use relative path  console will print the following warning

```
airdrop ./LICENSE ./README.md
2021-01-04 12:06:04.836 airdrop[6919:140388] NSURLs written to the pasteboard via NSPasteboardWriting must be absolute URLs.  NSURL 'LICENSE -- file:///Users/foo/pool/1d/pbadd/' is not an absolute URL.
2021-01-04 12:06:04.836 airdrop[6919:140388] NSURLs written to the pasteboard via NSPasteboardWriting must be absolute URLs.  NSURL 'LICENSE -- file:///Users/foo/pool/1d/pbadd/' is not an absolute URL.
Sending 2 files:
📩 LICENSE -- file:///Users/foo/pool/1d/pbadd/
📩 README.md -- file:///Users/foo/pool/1d/pbadd/

```

after standardize

```
Sending 2 files:
📩 file:///Volumes/coding/pbadd/LICENSE
📩 file:///Volumes/coding/pbadd/README.md
```

make the output  clean and concise.