### PR TITLE
Introduce FLAGS & DESTDIR variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 PREFIX ?= /usr/local
 BINDIR := $(PREFIX)/bin
 
+all: build
+
 build:
 	swift build -c release --disable-sandbox $(FLAGS)
 
@@ -14,4 +16,4 @@ uninstall:
 clean:
 	rm -rf .build
 
-.PHONY: build install uninstall clean
+.PHONY: all build install uninstall clean

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-prefix ?= /usr/local
-bindir = $(prefix)/bin
+PREFIX ?= /usr/local
+BINDIR := $(PREFIX)/bin
 
 build:
-	swift build -c release --disable-sandbox
+	swift build -c release --disable-sandbox $(FLAGS)
 
 install: build
-	install ".build/release/airdrop" "$(bindir)"
+	install ".build/release/airdrop" "$(BINDIR)"
 
 uninstall:
-	rm -rf "$(bindir)/airdrop"
+	rm -rf $(BINDIR)/airdrop
 
 clean:
 	rm -rf .build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 
 install: build
 	install -d $(DESTDIR)$(BINDIR)
-	install ".build/release/airdrop" "$(DESTDIR)$(BINDIR)"
+	install -m755 ".build/release/airdrop" "$(DESTDIR)$(BINDIR)"
 
 uninstall:
 	rm -rf $(DESTDIR)$(BINDIR)/airdrop

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ build:
 	swift build -c release --disable-sandbox $(FLAGS)
 
 install: build
-	install ".build/release/airdrop" "$(BINDIR)"
+	install -d $(DESTDIR)$(BINDIR)
+	install ".build/release/airdrop" "$(DESTDIR)$(BINDIR)"
 
 uninstall:
-	rm -rf $(BINDIR)/airdrop
+	rm -rf $(DESTDIR)$(BINDIR)/airdrop
 
 clean:
 	rm -rf .build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ devices using AirDrop from your terminal.
 
 ## Installation
 
-`airdrop-cli` is available for install with Homebrew
+`airdrop-cli` is available for install with [Homebrew](https://brew.sh/)
 
 ```
 brew install vldmrkl/formulae/airdrop-cli
@@ -21,7 +21,7 @@ brew install airdrop-cli
 ### Building from source
 
 Before attempting to build this project from its source code, make sure
-that you have Xcode version 11.4 (or higher) & GNU make installed.
+that you have Xcode version 11.4 (or higher) & GNU `make` installed.
 
 Then, clone the project and use the Makefile
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,63 @@
 # airdrop-cli
 
-This is a command line tool that allows you to share files and URLs with Apple devices using AirDrop from your terminal.
+A command-line tool that allows you to share files and URLs with Apple
+devices using AirDrop from your terminal.
 
 ## Installation
 
-### Prerequisites
-You need to have Xcode version 11.4 or higher installed.
+`airdrop-cli` is available for install with Homebrew
 
-### Homebrew
 ```
 brew install vldmrkl/formulae/airdrop-cli
 ```
+
 or
+
 ```
 brew tap vldmrkl/formulae
 brew install airdrop-cli
 ```
 
+### Building from source
 
-### Manually
+Before attempting to build this project from its source code, make sure
+that you have Xcode version 11.4 (or higher) & GNU make installed.
+
+Then, clone the project and use the Makefile
 
 ```
 git clone https://github.com/vldmrkl/airdrop-cli.git
 cd airdrop-cli
-make install
+make
+sudo make install
 ```
+
+By default, make will build and install the project within
+`/usr/local/bin`. This project location can be changed by appending
+a new prefix to the `PREFIX` variable.
+
+```
+make PREFIX="YOUR_PREFIX_HERE"
+```
+
+You can append other Swift flags, in case you may need them for your
+specific build, to the `FLAGS` variable.
 
 ## Usage
 
 ![airdrop-cli-demo](https://user-images.githubusercontent.com/26641473/103395121-762ef380-4afa-11eb-9bc8-6cf6068edf32.gif)
 
 To airdrop files, run:
+
 ```
 airdrop /path/to/your/file
 ```
 
 You can also airdrop URLs:
+
 ```
 airdrop https://apple.com/
 ```
 
-You can pass as many paths as you want. As long as theese file URLs are correct, the command will work.
+You can pass as many paths as you want. As long as theese file URLs are correct,
+the command will work.


### PR DESCRIPTION
This PR contains the following changes

- Introduce `FLAGS` and `DESTDIR` variables: This will allow other flags required for compiling on other targets be possible.
- Properly take care of installing after building: `install` is given the proper arguments for installation to take place

In short, the Makefile is now the main way to correctly build and install the project on any adequate environment.