### PR TITLE
Adds support for macOS Ventura

### DIFF
--- a/Sources/airdrop/AirDropCLI.swift
+++ b/Sources/airdrop/AirDropCLI.swift
@@ -48,6 +48,10 @@ class AirDropCLI:  NSObject, NSApplicationDelegate, NSSharingServiceDelegate {
         let pathsToFiles = Array(CommandLine.arguments[1 ..< argCount])
 
         shareFiles(pathsToFiles)
+
+        if #available(macOS 13.0, *) {
+            NSApp.setActivationPolicy(.accessory)
+        }
     }
 
     func getOption(_ option: String) -> (option:OptionType, value: String) {


### PR DESCRIPTION
This PR adds support for macOS Ventura by setting the app activation policy.

This resolves the following bug preventing interacting with the airdrop window:

<div>
<img src="https://user-images.githubusercontent.com/503337/202888870-4363cc48-334b-4d1d-a1cb-497f65aa825e.png" width="400">
<img src="https://user-images.githubusercontent.com/503337/202888871-f1ef22a8-2cf6-409d-aa2d-a2c95af66e29.png" width="400">
</div>

```
System Version: macOS 13.0.1 (22A400)
Model Name: MacBook Pro
Model Identifier: MacBookPro18,2
Model Number: MK1A3LL/A
Chip: Apple M1 Max
````
