### PR TITLE
Add a necessary fix to take window to front

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 
 install: build
 	install -d $(DESTDIR)$(BINDIR)
-	install -m755 ".build/release/airdrop" "$(DESTDIR)$(BINDIR)"
+	install -m 755 ".build/release/airdrop" "$(DESTDIR)$(BINDIR)"
 
 uninstall:
 	rm -rf $(DESTDIR)$(BINDIR)/airdrop

--- a/Sources/airdrop/AirDropCLI.swift
+++ b/Sources/airdrop/AirDropCLI.swift
@@ -115,6 +115,7 @@ class AirDropCLI:  NSObject, NSApplicationDelegate, NSSharingServiceDelegate {
 
         airDropMenuWindow.center()
         airDropMenuWindow.level = .popUpMenu
+        airDropMenuWindow.makeKeyAndOrderFront(nil)
 
         return airDropMenuWindow
     }


### PR DESCRIPTION
First of all, I wanted to say: thank you for your work!

This CLI is helping me SO much to improve my workflow during my dreaded examination period.

However, it seems like there was a bit of a focus issue with the NSWindow object that holds the airDropMenuWindow: when I first compiled and ran the CLI, I couldn't click on the popup menu,

I think a great solution would be to add a simple .makeKeyAndOrderFront(nil).

I tested it locally on my machine, and it works just fine.

Thank you so much again for a great tool!